### PR TITLE
Support version-based parameter group naming for Redis 7

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -45,7 +45,7 @@ resource "aws_elasticache_replication_group" "redis" {
 resource "aws_elasticache_parameter_group" "redis_parameter_group" {
 
   # tf-redis-sc-api-queue-dev
-  name = "tf-redis-${var.name}-${var.env}"
+  name   = "tf-redis-${var.name}-${var.env}-${local.parameter_group_family}"
 
   description = "Terraform-managed ElastiCache parameter group for ${var.name}-${var.env}"
 


### PR DESCRIPTION
Ref:- https://viooh.atlassian.net/browse/INFRA-14567

Support version-based parameter group naming for Redis major version upgrades

Redis 5 → 7 upgrade causes parameter group replacement because family cannot be modified. Existing module uses static naming, leading to conflict:

CacheParameterGroupAlreadyExists

Solution

Append ${local.parameter_group_family} to parameter group name to allow safe creation of new parameter group during major version upgrade.